### PR TITLE
Update lab_prepare docker installation

### DIFF
--- a/labs/03-user/lab-container/lab_prepare.sh
+++ b/labs/03-user/lab-container/lab_prepare.sh
@@ -2,7 +2,7 @@
 
 install_docker () {
     sudo apt-get update
-    sudo apt-get upgrade
+    sudo apt-get upgrade -y 
     curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
     sudo usermod -aG docker $USER
     sudo service docker start

--- a/labs/03-user/lab-container/lab_prepare.sh
+++ b/labs/03-user/lab-container/lab_prepare.sh
@@ -2,11 +2,9 @@
 
 install_docker () {
     sudo apt-get update
-    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
+    sudo apt-get upgrade
+    curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
+    sudo usermod -aG docker $USER
     sudo service docker start
 }
 

--- a/labs/07-networking/lab-container/lab_prepare.sh
+++ b/labs/07-networking/lab-container/lab_prepare.sh
@@ -2,11 +2,9 @@
 
 install_docker () {
     sudo apt-get update
-    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
+    sudo apt-get upgrade
+    curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
+    sudo usermod -aG docker $USER
     sudo service docker start
 }
 

--- a/labs/07-networking/lab-container/lab_prepare.sh
+++ b/labs/07-networking/lab-container/lab_prepare.sh
@@ -2,7 +2,7 @@
 
 install_docker () {
     sudo apt-get update
-    sudo apt-get upgrade
+    sudo apt-get upgrade -y
     curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
     sudo usermod -aG docker $USER
     sudo service docker start

--- a/labs/09-task-admin/lab-container/lab_prepare.sh
+++ b/labs/09-task-admin/lab-container/lab_prepare.sh
@@ -2,11 +2,9 @@
 
 install_docker () {
     sudo apt-get update
-    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
+    sudo apt-get upgrade
+    curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
+    sudo usermod -aG docker $USER
     sudo service docker start
 }
 

--- a/labs/09-task-admin/lab-container/lab_prepare.sh
+++ b/labs/09-task-admin/lab-container/lab_prepare.sh
@@ -2,7 +2,7 @@
 
 install_docker () {
     sudo apt-get update
-    sudo apt-get upgrade
+    sudo apt-get upgrade -y
     curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
     sudo usermod -aG docker $USER
     sudo service docker start


### PR DESCRIPTION
The previous script assumed that the arch was `amd64`.
This caused the setup to fail on `arm64` machines.

Replaced the steps with docker's script that does all the machinery in the back. [0]

Also, I added the current user to the `docker` group so the user won't be required to use `sudo` each time it interacts with docker.

[0] - https://www.docker.com/blog/getting-started-with-docker-for-arm-on-linux/