### PR TITLE
labs:lab03: Add hosts in `/etc/hosts` at build time correctly

### DIFF
--- a/labs/03-user/lab-container/docker-compose.yml
+++ b/labs/03-user/lab-container/docker-compose.yml
@@ -70,6 +70,8 @@ services:
     build:
       context: ./openvpn-client1/
       dockerfile: ./Dockerfile
+      extra_hosts:
+        - "openvpn:10.10.10.50"
     cap_add:
       - ALL
   openvpn-client2:
@@ -84,6 +86,8 @@ services:
     build:
       context: ./openvpn-client2/
       dockerfile: ./Dockerfile
+      extra_hosts:
+        - "openvpn:11.11.11.50"
     cap_add:
       - ALL
   dhcp:

--- a/labs/03-user/lab-container/openvpn-client1/Dockerfile
+++ b/labs/03-user/lab-container/openvpn-client1/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get install -y net-tools
 RUN apt-get install -y openvpn
 
 RUN apt-get -y clean
-RUN echo -e '10.10.10.50\topenvpn' > /etc/hosts
 
 RUN rm -rf /var/lib/apt/lists/*
 

--- a/labs/03-user/lab-container/openvpn-client2/Dockerfile
+++ b/labs/03-user/lab-container/openvpn-client2/Dockerfile
@@ -15,7 +15,6 @@ RUN apt-get install -y net-tools
 RUN apt-get install -y openvpn
 
 RUN apt-get -y clean
-RUN echo -e '11.11.11.50\topenvpn' > /etc/hosts
 
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Build for `openvpn-client1` and `openvpn-client2` containers was failing with `/bin/sh: 1: cannot create /etc/hosts: Read-only file system`.

According to [the documentation](https://docs.docker.com/engine/reference/run/#managing-etchosts), Docker may live update `/etc/hosts`. While the documentation also states that it can end up in an incomplete or corrupted state, it looks like in recent versions the file is made read-only.

This fix uses the [`extra-hosts`](https://docs.docker.com/compose/compose-file/05-services/#extra_hosts) option for docker compose (equivalent to the CLI option `--add-hosts`) to properly add entries to the `/etc/hosts` file.