### PR TITLE
Major fixes to lab03 infrastructure

### DIFF
--- a/labs/03-user/lab-container/lab_prepare.sh
+++ b/labs/03-user/lab-container/lab_prepare.sh
@@ -17,6 +17,8 @@ check_operation () {
         ;;
     delete)
         ;;
+    cleanup)
+        ;;
     *)
         echo "Wrong operation"
         exit 1
@@ -62,6 +64,15 @@ operation=$1
 section=$2
 
 check_operation $operation
+
+if test $operation == "cleanup"; then
+    sudo docker stop $(sudo docker ps -a -q) 2> /dev/null
+    sudo docker rm $(sudo docker ps -a -q) 2> /dev/null
+    sudo docker network ls 2> /dev/null | grep lab-container | cut -d" " -f1 | xargs -I{} sudo docker network rm {} 2> /dev/null
+    sudo docker network ls 2> /dev/null | grep labcontainer | cut -d" " -f1 | xargs -I{} sudo docker network rm {} 2> /dev/null
+    sudo docker image ls 2> /dev/null | grep lab09 | cut -d" " -f1 | xargs -I{} sudo docker image rm {} 2> /dev/null
+    exit 0
+fi
 
 if test $operation == "delete"; then
     sudo docker compose down

--- a/labs/03-user/lab-container/lab_prepare.sh
+++ b/labs/03-user/lab-container/lab_prepare.sh
@@ -64,7 +64,7 @@ section=$2
 check_operation $operation
 
 if test $operation == "delete"; then
-    sudo docker-compose down
+    sudo docker compose down
     exit 0
 fi
 
@@ -77,10 +77,10 @@ check_section $section
 
 if test $operation == "install"; then
     if test $section == "all"; then
-        sudo docker-compose up
+        sudo docker compose up
     else
-        sudo docker-compose up -d $section
-        sudo docker-compose up -d dhcp
+        sudo docker compose up -d $section
+        sudo docker compose up -d dhcp
     fi
 
 fi

--- a/labs/03-user/lab-container/lab_prepare.sh
+++ b/labs/03-user/lab-container/lab_prepare.sh
@@ -3,8 +3,7 @@
 install_docker () {
     sudo apt-get update
     sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
     sudo apt-get update
     sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
     sudo service docker start


### PR DESCRIPTION
The changes fix the following issue:
* ARM64 students could not install docker on their PCs;
* The `docker-compose` command has become deprecated and we have moved to using the `docker compose` module;
* Cleanup commands have been added to remove images, networks and containers from the machine when the lab finishes to free up space.