### PR TITLE
Fix docker installation

### DIFF
--- a/labs/03-user/lab-container/lab_prepare.sh
+++ b/labs/03-user/lab-container/lab_prepare.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
 install_docker () {
-    sudo apt-get update
-    sudo apt-get install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
-    curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
-    sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose
+    sudo apt update
+    sudo apt install -y apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+    $(. /etc/os-release && echo "${UBUNTU_CODENAME:-$VERSION_CODENAME}") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt update
+    sudo apt install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
     sudo service docker start
 }
 


### PR DESCRIPTION
The docker installation was using an obsolete script that was yeilding errors.

For the new script we are using the new guidelines from the official docker documentation: 
 https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository 